### PR TITLE
fix/>=python3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The depended python packages are listed in _requirements.txt_. The package versi
 
 ## How to run
 
-The program is in Python 3.6 using [Keras](https://keras.io/) and [Tensorflow](https://www.tensorflow.org/) backends. Use the below bash command to run RPITER.
+The program is in Python >=3.7 using [Keras](https://keras.io/) and [Tensorflow](https://www.tensorflow.org/) backends. Use the below bash command to run RPITER.
 
 ```bash
     python rpiter.py -d dataset

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
-numpy>=1.8.0
-tensorflow=1.10.0
-keras=2.2.2
-matplotlib>=2.0.0
-scikit-learn>=0.18.1
-h5py>=2.7.0
+numpy
+tensorflow
+matplotlib
+scikit-learn
+h5py

--- a/sample/rpiter.py
+++ b/sample/rpiter.py
@@ -8,11 +8,11 @@ from functools import reduce
 import configparser
 import numpy as np
 import tensorflow as tf
-from keras import optimizers
-from keras.layers import Dense, concatenate, BatchNormalization
-from keras.layers import Dropout
-from keras.models import Model
-from keras.utils import np_utils
+from tensorflow.keras import optimizers
+from tensorflow.keras.layers import Dense, concatenate, BatchNormalization
+from tensorflow.keras.layers import Dropout
+from tensorflow.keras.models import Model
+from tensorflow.keras.utils import to_categorical
 from sklearn.metrics import confusion_matrix
 from sklearn.metrics import roc_curve, auc
 from sklearn.model_selection import StratifiedKFold
@@ -168,13 +168,13 @@ def coding_pairs(pairs, pro_seqs, rna_seqs, pro_structs, rna_structs, PE, RE, ki
             p_conjoint_struct = PE.encode_conjoint_struct(p_seq, p_struct)
             r_conjoint_struct = RE.encode_conjoint_struct(r_seq, r_struct)
 
-            if p_conjoint is 'Error':
+            if type(p_conjoint) == str and p_conjoint == 'Error':
                 print('Skip {} in pair {} according to conjoint coding process.'.format(pr[0], pr))
-            elif r_conjoint is 'Error':
+            elif type(r_conjoint) == str and r_conjoint == 'Error':
                 print('Skip {} in pair {} according to conjoint coding process.'.format(pr[1], pr))
-            elif p_conjoint_struct is 'Error':
+            elif type(p_conjoint_struct) == str and p_conjoint_struct == 'Error':
                 print('Skip {} in pair {} according to conjoint_struct coding process.'.format(pr[0], pr))
-            elif r_conjoint_struct is 'Error':
+            elif type(r_conjoint_struct) == str and r_conjoint_struct == 'Error':
                 print('Skip {} in pair {} according to conjoint_struct coding process.'.format(pr[1], pr))
 
             else:
@@ -276,9 +276,9 @@ def get_callback_list(patience, result_path, stage, fold, X_test, y_test):
 
 def get_optimizer(opt_name):
     if opt_name == 'sgd':
-        return optimizers.sgd(lr=SGD_LEARNING_RATE, momentum=0.5)
+        return optimizers.SGD(learning_rate=SGD_LEARNING_RATE, momentum=0.5)
     elif opt_name == 'adam':
-        return optimizers.adam(lr=ADAM_LEARNING_RATE)
+        return optimizers.Adam(learning_rate=ADAM_LEARNING_RATE)
     else:
         return opt_name
 
@@ -406,9 +406,9 @@ for fold in range(K_FOLD):
     X_test_conjoint_previous = [X[4][0][test], X[4][1][test]]
 
     y_train_mono = y[train]
-    y_train = np_utils.to_categorical(y_train_mono, 2)
+    y_train = to_categorical(y_train_mono, 2)
     y_test_mono = y[test]
-    y_test = np_utils.to_categorical(y_test_mono, 2)
+    y_test = to_categorical(y_test_mono, 2)
 
     X_ensemble_train = X_train_conjoint + X_train_conjoint_struct + X_train_conjoint_cnn + X_train_conjoint_struct_cnn
     X_ensemble_test = X_test_conjoint + X_test_conjoint_struct + X_test_conjoint_cnn + X_test_conjoint_struct_cnn

--- a/sample/utils/basic_modules.py
+++ b/sample/utils/basic_modules.py
@@ -1,6 +1,6 @@
-from keras.layers import Dense, Conv1D, concatenate, BatchNormalization, MaxPooling1D
-from keras.layers import Dropout, Flatten, Input
-from keras.models import Model
+from tensorflow.keras.layers import Dense, Conv1D, concatenate, BatchNormalization, MaxPooling1D
+from tensorflow.keras.layers import Dropout, Flatten, Input
+from tensorflow.keras.models import Model
 
 
 def conjoint_cnn(pro_coding_length, rna_coding_length, vector_repeatition_cnn):

--- a/sample/utils/callbacks.py
+++ b/sample/utils/callbacks.py
@@ -4,7 +4,7 @@ matplotlib.use("Agg")
 import warnings
 import numpy as np
 import matplotlib.pyplot as plt
-from keras.callbacks import Callback
+from tensorflow.keras.callbacks import Callback
 
 
 # to consider version compatibility

--- a/sample/utils/stacked_auto_encoder.py
+++ b/sample/utils/stacked_auto_encoder.py
@@ -1,6 +1,6 @@
 import numpy as np
-from keras.layers import Dense, Dropout
-from keras.models import Sequential
+from tensorflow.keras.layers import Dense, Dropout
+from tensorflow.keras.models import Sequential
 
 
 def train_auto_encoder(X_train, X_test, layers, batch_size=100, nb_epoch=100, activation='sigmoid', optimizer='adam'):


### PR DESCRIPTION
Remove deprecation warnings and allow the tool to run with modern Python versions (>=3.7).